### PR TITLE
Mark functions as __time_critical_func to ensure fast response to polls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,4 +7,4 @@ add_custom_command(OUTPUT ${CMAKE_CURRENT_LIST_DIR}/generated/joybus.pio.h
         COMMAND Pioasm ${CMAKE_CURRENT_LIST_DIR}/joybus.pio ${CMAKE_CURRENT_LIST_DIR}/generated/joybus.pio.h
         )
 
-target_link_libraries(project pico_stdlib hardware_pio)
+target_link_libraries(project pico_stdlib pico_platform hardware_pio)


### PR DESCRIPTION
In the PhobGCC codebase I was having intermittent disconnections in Smashscope and the only thing that I could discern was that it was taking 34 microseconds to respond to the poll instead of the expected 8.5ish.

So I marked all the functions __time_critical_func and the problem went away.

This ensures that the functions remain cached in RAM for maximum performance. Otherwise, making seemingly unrelated code changes (or even entering different codepaths that call different functions) could evict the comms functions and make them run unexpectedly slowly.

See https://raspberrypi.github.io/pico-sdk-doxygen/group__pico__platform.html#ga27ef91000958320e25ff481d16786ebf